### PR TITLE
Feature: Add Error Snippet to Test Report Objects 

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,3 +20,4 @@ jobs:
       - run: npm run build
       - run: npm run lint-check
       - run: npm run format-check
+      - run: npm run test

--- a/src/generate-report.ts
+++ b/src/generate-report.ts
@@ -189,6 +189,7 @@ class GenerateCtrfReport implements Reporter {
       )
       test.message = this.extractFailureDetails(testResult).message
       test.trace = this.extractFailureDetails(testResult).trace
+      test.snippet = this.extractFailureDetails(testResult).snippet
       test.rawStatus = testResult.status
       test.tags = this.extractTagsFromTitle(testCase.title)
       test.type = this.reporterConfigOptions.testType ?? 'e2e'
@@ -380,6 +381,9 @@ class GenerateCtrfReport implements Reporter {
       }
       if (testResult.error.stack !== undefined) {
         failureDetails.trace = testResult.error.stack
+      }
+      if (testResult.error.snippet !== undefined) {
+        failureDetails.snippet = testResult.error.snippet
       }
       return failureDetails
     }

--- a/tests/dummy-suites/failed-test-suite.ts
+++ b/tests/dummy-suites/failed-test-suite.ts
@@ -1,0 +1,89 @@
+import {
+  type Suite,
+  type TestCase,
+  type Location,
+  type TestResult,
+  type TestError,
+} from '@playwright/test/reporter'
+
+/**
+ * Creates a minimal Suite object with a single failed test
+ */
+export const createFailedTestSuite = (): Suite => {
+  const testError: TestError = {
+    message: 'test-error-message',
+    stack: 'test-error-stack',
+    snippet: 'test-error-snippet',
+  }
+
+  const testResult: TestResult = {
+    retry: 0,
+    duration: 120,
+    status: 'failed',
+    startTime: new Date('2023-01-01T00:00:00.000Z'),
+    parallelIndex: 0,
+    workerIndex: 0,
+    attachments: [],
+    errors: [testError],
+    error: testError,
+    steps: [],
+    stdout: [],
+    stderr: [],
+  }
+
+  const testCase: TestCase = {
+    title: 'should validate the expected condition',
+    id: 'test-id-123',
+    annotations: [],
+    expectedStatus: 'passed',
+    timeout: 30000,
+    results: [testResult],
+    location: {
+      file: 'test-file.spec.ts',
+      line: 42,
+      column: 3,
+    },
+    parent: undefined as any, // Will be set later
+    outcome: () => 'unexpected',
+    ok: () => false,
+    titlePath: () => [
+      'Failed Test Suite',
+      'should validate the expected condition',
+    ],
+    repeatEachIndex: 0,
+    retries: 0,
+  }
+
+  const suite: Suite = {
+    title: 'Failed Test Suite',
+    titlePath: () => ['Failed Test Suite'],
+    location: {
+      file: 'test-file.spec.ts',
+      line: 10,
+      column: 1,
+    } as Location,
+    project: () => ({
+      name: 'Test Project',
+      outputDir: './test-results',
+      grep: /.*/,
+      grepInvert: null,
+      metadata: {},
+      dependencies: [],
+      repeatEach: 1,
+      retries: 0,
+      timeout: 30000,
+      use: {},
+      testDir: './tests',
+      testIgnore: [],
+      testMatch: [],
+      snapshotDir: './snapshots',
+    }),
+    allTests: () => [testCase],
+    tests: [testCase],
+    suites: [],
+  }
+
+  testCase.parent = suite
+
+  return suite
+}

--- a/tests/failed-tests.spec.ts
+++ b/tests/failed-tests.spec.ts
@@ -1,0 +1,37 @@
+import { createFailedTestSuite } from './dummy-suites/failed-test-suite'
+import GenerateCtrfReport from '../src/generate-report'
+import fs from 'fs'
+import { CtrfReport } from '../types/ctrf'
+
+jest.mock('fs', () => ({
+  writeFileSync: jest.fn(),
+  existsSync: jest.fn(() => true),
+}))
+const nowDateMock = new Date('2023-01-01T00:00:00.000Z')
+jest.useFakeTimers().setSystemTime(nowDateMock)
+
+const mockedFs = fs as jest.Mocked<typeof fs>
+
+describe('Failed Tests', () => {
+  it('should generate report with error details correctly', async () => {
+    // Arrange
+    const testSuite = createFailedTestSuite()
+    const report = new GenerateCtrfReport()
+
+    // Act
+    report.onBegin(undefined as any, testSuite)
+    report.onEnd()
+
+    // Assert
+    expect(mockedFs.writeFileSync).toHaveBeenCalledTimes(1)
+
+    const reportJsonContent = mockedFs.writeFileSync.mock.calls[0][1] as string
+    const parsedReport: CtrfReport = JSON.parse(reportJsonContent)
+
+    expect(parsedReport.results.tests).toHaveLength(1)
+    expect(parsedReport.results.tests[0].status).toBe('failed')
+    expect(parsedReport.results.tests[0].message).toBe('test-error-message')
+    expect(parsedReport.results.tests[0].trace).toBe('test-error-stack')
+    expect(parsedReport.results.tests[0].snippet).toBe('test-error-snippet')
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,6 @@
     "rootDir": "./src",
     "declaration": true,
     "forceConsistentCasingInFileNames": true
-  }
+  },
+  "include": ["src/**/*"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDirs": ["src", "tests"],
+    "noEmit": true
+  }
+}

--- a/types/ctrf.d.ts
+++ b/types/ctrf.d.ts
@@ -32,6 +32,7 @@ export interface CtrfTest {
   suite?: string
   message?: string
   trace?: string
+  snippet?: string
   rawStatus?: string
   tags?: string[]
   type?: string


### PR DESCRIPTION
The issue being raised for this PR is #20

I added two commits:

- One to add the `snippet` property
- Another one to add a simple test

I split it into two commits, because this was the first test and you might just want to include the actual implementation in the main repo. Feel free to omit the second commit in this case.

Personally i think it's valuable to gradually add such simple tests :)

Let me know what you think.